### PR TITLE
Add ability to add events to sheet

### DIFF
--- a/DiscordBot.DataAccess/EventsSheetsInitialisationException.cs
+++ b/DiscordBot.DataAccess/EventsSheetsInitialisationException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace DiscordBot.DataAccess
+{
+    public class EventsSheetsInitialisationException : Exception
+    {
+        public EventsSheetsInitialisationException(string? message) : base(message) { }
+
+        public EventsSheetsInitialisationException(string? message, Exception? innerException)
+            : base(message, innerException) { }
+    }
+}

--- a/DiscordBot.DataAccess/EventsSheetsService.cs
+++ b/DiscordBot.DataAccess/EventsSheetsService.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using DiscordBot.Models;
+using Google;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Sheets.v4;
@@ -28,6 +30,8 @@ namespace DiscordBot.DataAccess
         private static readonly string spreadsheetId = "";
 
         private readonly SheetsService sheetsService;
+        private int largestKey;
+        private readonly Dictionary<int, int> keyToRowNumberMap;
 
         public EventsSheetsService()
         {
@@ -38,6 +42,37 @@ namespace DiscordBot.DataAccess
                 HttpClientInitializer = credential,
                 ApplicationName = applicationName
             });
+
+            try
+            {
+                var request = sheetsService.Spreadsheets.Values.Get(spreadsheetId, "EventsMetadata!A:A");
+                var response = request.Execute();
+
+                if (response == null || response.Values.Count < 1)
+                {
+                    throw new EventsSheetsInitialisationException("Metadata sheet is empty");
+                }
+
+                // Find which row each event is on, and the largest key in use
+                keyToRowNumberMap = new Dictionary<int, int>();
+                var keys = response.Values.Skip(1);
+                largestKey =
+                    keys
+                    .Select((keyRow, rowNumber) =>
+                        {
+                            var key = int.Parse((string) keyRow[0]);
+                            keyToRowNumberMap.Add(key, rowNumber + 1);
+                            return key;
+                        })
+                    .Max();
+            }
+            catch (GoogleApiException exception)
+            {
+                throw new EventsSheetsInitialisationException(
+                    $"Events Sheets Service couldn't initialise",
+                    exception
+                );
+            }
         }
 
         public async Task ReadColumns()
@@ -83,6 +118,39 @@ namespace DiscordBot.DataAccess
 
         public async Task AddEventAsync(string name, string description, DateTime time)
         {
+            // Allocate new key
+            largestKey++;
+
+            var newRow = new ValueRange
+            {
+                Values = new IList<object>[]
+                {
+                    new object[]
+                    {
+                        largestKey,
+                        name,
+                        description,
+                        time.ToString("s"),
+                        "Europe/London"
+                    }
+                }
+            };
+
+            var request = sheetsService.Spreadsheets.Values.Append(
+                newRow,
+                spreadsheetId,
+                "A:E"
+            );
+            request.ValueInputOption = AppendRequest.ValueInputOptionEnum.RAW;
+
+            var response = await request.ExecuteAsync();
+
+            // Record which row the new event was inserted on
+            keyToRowNumberMap.Add(
+                largestKey,
+                GetRowNumberFromRange(response.Updates.UpdatedRange)
+            );
+            return;
         }
 
         public async Task EditEventAsync(
@@ -118,6 +186,13 @@ namespace DiscordBot.DataAccess
             return GoogleCredential.FromStream(stream)
                 .CreateScoped(scopes)
                 .UnderlyingCredential as ServiceAccountCredential;
+        }
+
+        private int GetRowNumberFromRange(string range)
+        {
+            const string pattern = @"^EventsMetadata!A\d+:E(\d+)$";
+            var rowString = Regex.Match(range, pattern).Groups[1].ToString();
+            return int.Parse(rowString);
         }
     }
 }

--- a/DiscordBot.DataAccess/EventsSheetsService.cs
+++ b/DiscordBot.DataAccess/EventsSheetsService.cs
@@ -31,7 +31,6 @@ namespace DiscordBot.DataAccess
 
         private readonly SheetsService sheetsService;
         private int largestKey;
-        private readonly Dictionary<int, int> keyToRowNumberMap;
 
         public EventsSheetsService()
         {
@@ -43,36 +42,7 @@ namespace DiscordBot.DataAccess
                 ApplicationName = applicationName
             });
 
-            try
-            {
-                var request = sheetsService.Spreadsheets.Values.Get(spreadsheetId, "EventsMetadata!A:A");
-                var response = request.Execute();
-
-                if (response == null || response.Values.Count < 1)
-                {
-                    throw new EventsSheetsInitialisationException("Metadata sheet is empty");
-                }
-
-                // Find which row each event is on, and the largest key in use
-                keyToRowNumberMap = new Dictionary<int, int>();
-                var keys = response.Values.Skip(1);
-                largestKey =
-                    keys
-                    .Select((keyRow, rowNumber) =>
-                        {
-                            var key = int.Parse((string) keyRow[0]);
-                            keyToRowNumberMap.Add(key, rowNumber + 1);
-                            return key;
-                        })
-                    .Max();
-            }
-            catch (GoogleApiException exception)
-            {
-                throw new EventsSheetsInitialisationException(
-                    $"Events Sheets Service couldn't initialise",
-                    exception
-                );
-            }
+            largestKey = GetLargestKey();
         }
 
         public async Task ReadColumns()
@@ -143,14 +113,7 @@ namespace DiscordBot.DataAccess
             );
             request.ValueInputOption = AppendRequest.ValueInputOptionEnum.RAW;
 
-            var response = await request.ExecuteAsync();
-
-            // Record which row the new event was inserted on
-            keyToRowNumberMap.Add(
-                largestKey,
-                GetRowNumberFromRange(response.Updates.UpdatedRange)
-            );
-            return;
+            await request.ExecuteAsync();
         }
 
         public async Task EditEventAsync(
@@ -188,11 +151,33 @@ namespace DiscordBot.DataAccess
                 .UnderlyingCredential as ServiceAccountCredential;
         }
 
-        private int GetRowNumberFromRange(string range)
+        private int GetLargestKey()
         {
-            const string pattern = @"^EventsMetadata!A\d+:E(\d+)$";
-            var rowString = Regex.Match(range, pattern).Groups[1].ToString();
-            return int.Parse(rowString);
+            try
+            {
+                var request = sheetsService.Spreadsheets.Values.Get(spreadsheetId, "EventsMetadata!A:A");
+                var response = request.Execute();
+
+                if (response == null || response.Values.Count < 1)
+                {
+                    throw new EventsSheetsInitialisationException("Metadata sheet is empty");
+                }
+
+                // If the table only contains headers, and no data
+                if (response.Values.Count == 1)
+                {
+                    return 0;
+                }
+
+                return int.Parse((string)response.Values.Skip(1).Last()[0]);
+            }
+            catch (GoogleApiException exception)
+            {
+                throw new EventsSheetsInitialisationException(
+                    $"Events Sheets Service couldn't initialise",
+                    exception
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
To do this: add tracking of largest key in use, and get this from the
sheet on service construction. Also, add a dictionary to map between
event keys and rows; this will come in useful when editing and
deleting events, and make sure the event adding method keeps these
up to date.

For context, when events are deleted either the will be blank rows in
the sheet, or the event key will not correspond to the row number of
the event. I chose the second option, so we need to keep track of this
mapping.