### PR TITLE
Add conversation for editing events

### DIFF
--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -181,14 +181,13 @@ namespace DiscordBot.Commands
             {
                 var eventsSheetService = context.Dependencies.GetDependency<IEventsSheetsService>();
                 await eventsSheetService.EditEventAsync(eventKey, newDescription, newName, newTime);
-                await context.RespondAsync($"{context.Member.Mention} - changes saved!");
+                await context.RespondAsync($"{context.Member.Mention} - changes saved!", embed: eventEmbed);
             }
             catch (EventNotFoundException)
             {
                 await context.RespondAsync($"{context.Member.Mention} - operation stopped: event not found");
             }
         }
-
 
         private static async Task<DiscordEmbedBuilder?> GetEventEmbed(CommandContext context, int eventKey)
         {

--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -86,7 +86,7 @@ namespace DiscordBot.Commands
 
             await eventsSheetService.AddEventAsync(eventName, eventDescription, eventTime.Value.DateTime);
 
-            var discordEmbed = new DiscordEmbedBuilder
+            var eventEmbed = new DiscordEmbedBuilder
             {
                 Title = eventName,
                 Description = eventDescription,
@@ -94,7 +94,7 @@ namespace DiscordBot.Commands
                 Timestamp = eventTime
             };
 
-            await context.RespondAsync(embed: discordEmbed);
+            await context.RespondAsync(embed: eventEmbed);
         }
 
         public async Task EditEvent(CommandContext context, InteractivityModule interactivity)
@@ -106,13 +106,13 @@ namespace DiscordBot.Commands
                 return;
             }
 
-            var discordEmbed = await GetEventEmbed(context, eventKey.Value);
-            if (discordEmbed == null)
+            var eventEmbed = await GetEventEmbed(context, eventKey.Value);
+            if (eventEmbed == null)
             {
                 return;
             }
 
-            await context.RespondAsync($"{context.Member.Mention}", embed: discordEmbed);
+            await context.RespondAsync($"{context.Member.Mention}", embed: eventEmbed);
             await context.RespondAsync(
                 $"{context.Member.Mention} - what field do you want to edit? (``name``, ``description``, ``time``)\n" +
                 "``save`` to save changes.");
@@ -122,7 +122,7 @@ namespace DiscordBot.Commands
                 return;
             }
 
-            await EditEventField(context, interactivity, eventKey.Value, editField, discordEmbed);
+            await EditEventField(context, interactivity, eventKey.Value, editField, eventEmbed);
         }
 
         private static async Task EditEventField(
@@ -130,7 +130,7 @@ namespace DiscordBot.Commands
             InteractivityModule interactivity,
             int eventKey,
             string editField,
-            DiscordEmbedBuilder discordEmbed)
+            DiscordEmbedBuilder eventEmbed)
         {
             string? newName = null;
             string? newDescription = null;
@@ -146,7 +146,7 @@ namespace DiscordBot.Commands
                         return;
                     }
 
-                    discordEmbed.Title = newName;
+                    eventEmbed.Title = newName;
                     break;
                 case "description":
                     await context.RespondAsync($"{context.Member.Mention} - enter the new description.");
@@ -156,7 +156,7 @@ namespace DiscordBot.Commands
                         return;
                     }
 
-                    discordEmbed.Description = newDescription;
+                    eventEmbed.Description = newDescription;
                     break;
                 case "time":
                     await context.RespondAsync($"{context.Member.Mention} - enter the new event time.");
@@ -166,7 +166,7 @@ namespace DiscordBot.Commands
                         return;
                     }
 
-                    discordEmbed.Timestamp = newTime.Value.DateTime;
+                    eventEmbed.Timestamp = newTime.Value.DateTime;
                     break;
             }
 
@@ -180,7 +180,7 @@ namespace DiscordBot.Commands
                 await context.RespondAsync($"{context.Member.Mention} - operation stopped: event not found");
             }
 
-            await context.RespondAsync($"{context.Member.Mention} - changes saved!", embed: discordEmbed);
+            await context.RespondAsync($"{context.Member.Mention} - changes saved!", embed: eventEmbed);
         }
 
         private static async Task<DiscordEmbedBuilder?> GetEventEmbed(CommandContext context, int eventKey)

--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Threading.Tasks;
 using DiscordBot.DataAccess;
-using DiscordBot.DataAccess.Models;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;

--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -124,10 +124,10 @@ namespace DiscordBot.Commands
                 return;
             }
 
-            await EditEventFields(context, interactivity, eventKey.Value, editField, discordEmbed);
+            await EditEventField(context, interactivity, eventKey.Value, editField, discordEmbed);
         }
 
-        private static async Task EditEventFields(
+        private static async Task EditEventField(
             CommandContext context,
             InteractivityModule interactivity,
             int eventKey,

--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -164,7 +164,7 @@ namespace DiscordBot.Commands
                     }
 
                     eventEmbed.Timestamp = newTime.Value.DateTime;
-                    await TryEditEvent(context, eventKey, eventEmbed, newTime: newTime?.DateTime);
+                    await TryEditEvent(context, eventKey, eventEmbed, newTime: newTime.Value.DateTime);
                     break;
             }
         }

--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -88,7 +88,7 @@ namespace DiscordBot.Commands
 
             await eventsSheetService.AddEventAsync(eventName, eventDescription, eventTime.Value.DateTime);
 
-            var embed = new DiscordEmbedBuilder
+            var discordEmbed = new DiscordEmbedBuilder
             {
                 Title = eventName,
                 Description = eventDescription,
@@ -96,7 +96,7 @@ namespace DiscordBot.Commands
                 Timestamp = eventTime
             };
 
-            await context.RespondAsync(embed: embed);
+            await context.RespondAsync(embed: discordEmbed);
         }
 
         public async Task EditEvent(CommandContext context, InteractivityModule interactivity)
@@ -108,20 +108,20 @@ namespace DiscordBot.Commands
                 return;
             }
 
-            var embed = await GetEventEmbed(context, eventKey.Value);
-            if (embed == null)
+            var discordEmbed = await GetEventEmbed(context, eventKey.Value);
+            if (discordEmbed == null)
             {
                 return;
             }
 
-            await EditEventFields(context, interactivity, eventKey.Value, embed);
+            await EditEventFields(context, interactivity, eventKey.Value, discordEmbed);
         }
 
         private static async Task EditEventFields(
             CommandContext context,
             InteractivityModule interactivity,
             int eventKey,
-            DiscordEmbedBuilder embed)
+            DiscordEmbedBuilder discordEmbed)
         {
             string? newName = null;
             string? newDescription = null;
@@ -129,7 +129,7 @@ namespace DiscordBot.Commands
 
             while (true)
             {
-                await context.RespondAsync($"{context.Member.Mention}", embed: embed);
+                await context.RespondAsync($"{context.Member.Mention}", embed: discordEmbed);
                 await context.RespondAsync(
                     $"{context.Member.Mention} - what field do you want to edit? (``name``, ``description``, ``time``)\n" +
                     "``save`` to save changes.");
@@ -149,7 +149,7 @@ namespace DiscordBot.Commands
                             return;
                         }
 
-                        embed.Title = newName;
+                        discordEmbed.Title = newName;
                         break;
                     case "description":
                         await context.RespondAsync($"{context.Member.Mention} - enter the new description.");
@@ -159,7 +159,7 @@ namespace DiscordBot.Commands
                             return;
                         }
 
-                        embed.Description = newDescription;
+                        discordEmbed.Description = newDescription;
                         break;
                     case "time":
                         await context.RespondAsync($"{context.Member.Mention} - enter the new event time.");
@@ -169,7 +169,7 @@ namespace DiscordBot.Commands
                             return;
                         }
 
-                        embed.Timestamp = newTime.Value.DateTime;
+                        discordEmbed.Timestamp = newTime.Value.DateTime;
                         break;
                     case "save":
                         try

--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -24,7 +24,6 @@ namespace DiscordBot.Commands
             "name",
             "description",
             "time",
-            "save",
             "stop"
         };
 


### PR DESCRIPTION
The user can now edit existing events by interacting with the bot.

New features rely on GetEvent which is currently hardcoded and bugs may arise once that is implemented.