### PR TITLE
Add interface to SheetsService for events signup

### DIFF
--- a/DiscordBot.DataAccess/EventsSheetsService.cs
+++ b/DiscordBot.DataAccess/EventsSheetsService.cs
@@ -15,7 +15,12 @@ namespace DiscordBot.DataAccess
 {
     public interface IEventsSheetsService
     {
-        Task AddEventAsync(string name, string description, DateTime time);
+        Task AddEventAsync(
+            string name,
+            string description,
+            DateTime time,
+            IEnumerable<EventResponse>? responses = null
+        );
         Task EditEventAsync(
             int eventKey,
             string? description = null,
@@ -26,6 +31,12 @@ namespace DiscordBot.DataAccess
 
         Task<DiscordEvent> GetEventAsync(int eventKey);
         Task<IEnumerable<DiscordEvent>> ListEventsAsync();
+
+        Task AddResponseOfUser(int eventKey, ulong userId, string responseEmoji);
+        Task ClearResponsesOfUser(int eventKey, ulong userId);
+
+        Task<Dictionary<ulong, IEnumerable<EventResponse>>> GetSignupsByUser(int eventId);
+        Task<Dictionary<EventResponse, IEnumerable<ulong>>> GetSignupsByResponse(int eventId);
     }
 
     public class EventsSheetsService : IEventsSheetsService
@@ -59,8 +70,19 @@ namespace DiscordBot.DataAccess
             metadataSheetId = GetMetadataSheetId();
         }
 
-        public async Task AddEventAsync(string name, string description, DateTime time)
+        public async Task AddEventAsync(
+            string name,
+            string description,
+            DateTime time,
+            IEnumerable<EventResponse>? responses = null
+        )
         {
+            responses ??= new[]
+            {
+                new EventResponse(":white_check_mark:", "Yes"),
+                new EventResponse(":grey_question:", "Maybe")
+            };
+
             // Allocate new key
             largestKey++;
 
@@ -207,6 +229,34 @@ namespace DiscordBot.DataAccess
                 );
             }
         }
+
+#pragma warning disable 1998 // Disable compiler warning stating that the unimplemented functions are synchronous
+        public async Task AddResponseOfUser(int eventKey, ulong userId, string responseEmoji)
+        {
+        }
+
+        public async Task ClearResponsesOfUser(int eventKey, ulong userId)
+        {
+        }
+
+        public async Task<Dictionary<ulong, IEnumerable<EventResponse>>> GetSignupsByUser(int eventId)
+        {
+            return new Dictionary<ulong, IEnumerable<EventResponse>>
+            {
+                { 0UL, new[] { new EventResponse(":white_check_mark:", "Yes") } },
+                { 1UL, new[] { new EventResponse(":grey_question:", "Maybe") } }
+            };
+        }
+
+        public async Task<Dictionary<EventResponse, IEnumerable<ulong>>> GetSignupsByResponse(int eventId)
+        {
+            return new Dictionary<EventResponse, IEnumerable<ulong>>
+            {
+                { new EventResponse(":white_check_mark:", "Yes"), new[] { 0UL } },
+                { new EventResponse(":grey_question:", "Maybe"), new[] { 1UL } }
+            };
+        }
+#pragma warning restore 1998
 
         private static ServiceAccountCredential GetCredential(string path = "credentials.json")
         {

--- a/DiscordBot.DataAccess/EventsSheetsService.cs
+++ b/DiscordBot.DataAccess/EventsSheetsService.cs
@@ -32,8 +32,8 @@ namespace DiscordBot.DataAccess
         Task<DiscordEvent> GetEventAsync(int eventKey);
         Task<IEnumerable<DiscordEvent>> ListEventsAsync();
 
-        Task AddResponseOfUser(int eventKey, ulong userId, string responseEmoji);
-        Task ClearResponsesOfUser(int eventKey, ulong userId);
+        Task AddResponseForUser(int eventKey, ulong userId, string responseEmoji);
+        Task ClearResponsesForUser(int eventKey, ulong userId);
 
         Task<Dictionary<ulong, IEnumerable<EventResponse>>> GetSignupsByUser(int eventId);
         Task<Dictionary<EventResponse, IEnumerable<ulong>>> GetSignupsByResponse(int eventId);
@@ -231,11 +231,11 @@ namespace DiscordBot.DataAccess
         }
 
 #pragma warning disable 1998 // Disable compiler warning stating that the unimplemented functions are synchronous
-        public async Task AddResponseOfUser(int eventKey, ulong userId, string responseEmoji)
+        public async Task AddResponseForUser(int eventKey, ulong userId, string responseEmoji)
         {
         }
 
-        public async Task ClearResponsesOfUser(int eventKey, ulong userId)
+        public async Task ClearResponsesForUser(int eventKey, ulong userId)
         {
         }
 

--- a/DiscordBot.DataAccess/Models/EventResponse.cs
+++ b/DiscordBot.DataAccess/Models/EventResponse.cs
@@ -18,12 +18,10 @@ namespace DiscordBot.DataAccess.Models
             return Emoji == other.Emoji && ResponseName == other.ResponseName;
         }
 
-        public override bool Equals(object? obj)
+        public override bool Equals(object? other)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((EventResponse) obj);
+            if (other == null || other.GetType() != GetType()) return false;
+            return Equals((EventResponse) other);
         }
 
         public override int GetHashCode()

--- a/DiscordBot.DataAccess/Models/EventResponse.cs
+++ b/DiscordBot.DataAccess/Models/EventResponse.cs
@@ -4,18 +4,18 @@ namespace DiscordBot.DataAccess.Models
 {
     public class EventResponse
     {
-        public string emoji { get; }
-        public string responseName { get; }
+        public string Emoji { get; }
+        public string ResponseName { get; }
 
         public EventResponse(string emoji, string responseName)
         {
-            this.emoji = emoji;
-            this.responseName = responseName;
+            Emoji = emoji;
+            ResponseName = responseName;
         }
 
         protected bool Equals(EventResponse other)
         {
-            return emoji == other.emoji && responseName == other.responseName;
+            return Emoji == other.Emoji && ResponseName == other.ResponseName;
         }
 
         public override bool Equals(object? obj)
@@ -28,7 +28,7 @@ namespace DiscordBot.DataAccess.Models
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(emoji, responseName);
+            return HashCode.Combine(Emoji, ResponseName);
         }
     }
 }

--- a/DiscordBot.DataAccess/Models/EventResponse.cs
+++ b/DiscordBot.DataAccess/Models/EventResponse.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace DiscordBot.DataAccess.Models
+{
+    public class EventResponse
+    {
+        public string emoji { get; }
+        public string responseName { get; }
+
+        public EventResponse(string emoji, string responseName)
+        {
+            this.emoji = emoji;
+            this.responseName = responseName;
+        }
+
+        protected bool Equals(EventResponse other)
+        {
+            return emoji == other.emoji && responseName == other.responseName;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((EventResponse) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(emoji, responseName);
+        }
+    }
+}


### PR DESCRIPTION
@kwunkiuma and I had a look at making the next part of the interface between the `EventsSheetsService` and the Discord Bot. The table structure we settled on is:

User id | :key: | :shield: | :runner: | :dart: | :clipboard: | :telescope:
-------- | ------------ | ---------- | --------- | ------- | --------- | ----------
ResponseName | Goalkeeper | Defender | Midfield | Striker | Referee | Spectator
Alice | 0 | 1 | 0 | 0 | 0 | 0
Bob | 0 | 0 | 0 | 1 | 0 | 0
Charlie | 0 | 0 | 1 | 0 | 0 | 0
David | 1 | 1 | 0 | 0 | 0 | 0
Eve | 0 | 0 | 0 | 0 | 1 | 0

The only change is that we're indexing event responses based on emoji, rather than their names. This that makes more sense with how the discord bot will be indexing events; based on emoji reactions to a message.

The two get methods correspond to producing a dictionary indexed by the rows of this table, or the columns. 

Adding individual responses correspond to adding a reaction to the message (which the discord bot will then delete from the message when it has processed it), and clearing all responses for the user will correspond to a reaction that removes all response to an event from that user.