### PR TITLE
Add conversation for removing events

### DIFF
--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -15,7 +15,6 @@ namespace DiscordBot.Commands
         {
             "create",
             "remove",
-            "rm",
             "edit",
             "stop"
         };
@@ -57,7 +56,6 @@ namespace DiscordBot.Commands
                     await CreateEvent(context, interactivity);
                     break;
                 case "remove":
-                case "rm":
                     await RemoveEvent(context, interactivity);
                     break;
                 case "edit":


### PR DESCRIPTION
The user can now remove events by interacting with the bot.

The bot prompts the user for an event ID and asks the user for confirmation before deleting the event.