### PR TITLE
Add conversation for showing an event

### DIFF
--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -114,7 +114,7 @@ namespace DiscordBot.Commands
 
         public async Task RemoveEvent(CommandContext context, InteractivityModule interactivity)
         {
-            await context.RespondAsync($"{context.Member.Mention} - which event do you want to delete");
+            await context.RespondAsync($"{context.Member.Mention} - what is the event key? (use the ``list`` option to find out)");
             var eventKey = await GetUserIntResponse(context, interactivity);
             if (eventKey == null)
             {
@@ -153,7 +153,7 @@ namespace DiscordBot.Commands
 
         public async Task ShowEvent(CommandContext context, InteractivityModule interactivity)
         {
-            await context.RespondAsync($"{context.Member.Mention} - what is the event key?");
+            await context.RespondAsync($"{context.Member.Mention} - what is the event key? (use the ``list`` option to find out)");
             var eventKey = await GetUserIntResponse(context, interactivity);
             if (eventKey == null)
             {
@@ -191,7 +191,7 @@ namespace DiscordBot.Commands
 
         public async Task EditEvent(CommandContext context, InteractivityModule interactivity)
         {
-            await context.RespondAsync($"{context.Member.Mention} - what is the event key?");
+            await context.RespondAsync($"{context.Member.Mention} - what is the event key? (use the ``list`` option to find out)");
             var eventKey = await GetUserIntResponse(context, interactivity);
             if (eventKey == null)
             {

--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -15,6 +15,7 @@ namespace DiscordBot.Commands
         {
             "create",
             "remove",
+            "show",
             "edit",
             "stop"
         };
@@ -41,6 +42,7 @@ namespace DiscordBot.Commands
                 $"{context.Member.Mention} - choose one of the actions below or answer ``stop`` to cancel. (time out in 30s)\n" +
                 "``create`` - create new event.\n" +
                 "``remove`` - delete event.\n" +
+                "``show`` - show event details.\n" +
                 "``edit`` - edit event.\n"
             );
 
@@ -57,6 +59,9 @@ namespace DiscordBot.Commands
                     break;
                 case "remove":
                     await RemoveEvent(context, interactivity);
+                    break;
+                case "show":
+                    await ShowEvent(context, interactivity);
                     break;
                 case "edit":
                     await EditEvent(context, interactivity);
@@ -139,6 +144,24 @@ namespace DiscordBot.Commands
                     await context.RespondAsync($"{context.Member.Mention} - operation stopped: event not found");
                 }
             }
+        }
+
+        public async Task ShowEvent(CommandContext context, InteractivityModule interactivity)
+        {
+            await context.RespondAsync($"{context.Member.Mention} - what is the event key?");
+            var eventKey = await GetUserIntResponse(context, interactivity);
+            if (eventKey == null)
+            {
+                return;
+            }
+            
+            var eventEmbed = await GetEventEmbed(context, eventKey.Value);
+            if (eventEmbed == null)
+            {
+                return;
+            }
+            
+            await context.RespondAsync($"{context.Member.Mention} - here is the event", embed: eventEmbed);
         }
 
         public async Task EditEvent(CommandContext context, InteractivityModule interactivity)


### PR DESCRIPTION
The bot can display detailed information of a specific event specified by event key.

More information (e.g. signups) will be displayed once those features are implemented.