### PR TITLE
Ignore launch settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -371,3 +371,6 @@ DiscordBot.DataAccess/*credentials.json
 
 # Ignore Azure deployment settings
 DiscordBot/Settings.job
+
+# Ignore launch settings file (containing API keys at the moment)
+**/*launchSettings.json


### PR DESCRIPTION
We are only using these files for secrets at the moment. If we set up
secret manager to do this then we should revert this commit.