### PR TITLE
Add signup message creation

### DIFF
--- a/DiscordBot.DataAccess/Models/EventResponse.cs
+++ b/DiscordBot.DataAccess/Models/EventResponse.cs
@@ -28,5 +28,10 @@ namespace DiscordBot.DataAccess.Models
         {
             return HashCode.Combine(Emoji, ResponseName);
         }
+
+        public override string ToString()
+        {
+            return Emoji;
+        }
     }
 }

--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -261,19 +261,26 @@ namespace DiscordBot.Commands
 
             var userResponseDictionary = await eventsSheetsService.GetSignupsByUserAsync(eventKey);
 
-            var usersField = string.Join("\n", userResponseDictionary.Select(
-                response => $"<@{response.Key}>"));
+            var usersField = string.Join(
+                "\n",
+                userResponseDictionary.Select(response => $"<@{response.Key}>")
+            );
+
             signupEmbed.AddField("Participants", usersField, true);
 
             var responsesList = userResponseDictionary.Select(
-                response => string.Join(" ", response.Value));
+                response => string.Join(" ", response.Value)
+            );
             var responsesField = string.Join("\n", responsesList);
-            signupEmbed.AddField("Responses", responsesField, true);
+
+            signupEmbed.AddField("Response(s)", responsesField, true);
 
             var optionsList = await eventsSheetsService.GetSignupsByResponseAsync(eventKey);
             var optionsField = string.Join(
-                "\n", optionsList.Select(response =>
-                    $"{response.Key.Emoji} - {response.Key.ResponseName}"));
+                "\n",
+                optionsList.Select(response => $"{response.Key.Emoji} - {response.Key.ResponseName}")
+            );
+
             signupEmbed.AddField("Response options", optionsField);
 
             var signupMessage = await context.RespondAsync($"Signups are open for __**{discordEvent.Name}**__!", embed: signupEmbed);
@@ -284,6 +291,8 @@ namespace DiscordBot.Commands
                 await signupMessage.CreateReactionAsync(DiscordEmoji.FromName(context.Client, response.Emoji));
             }
         }
+
+
 
         private static async Task EditEventField(
             CommandContext context,

--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -292,8 +292,6 @@ namespace DiscordBot.Commands
             }
         }
 
-
-
         private static async Task EditEventField(
             CommandContext context,
             InteractivityModule interactivity,


### PR DESCRIPTION
The bot can now create a signup message for members to react to.

For now, reacting to the message doesn't do anything and the message is sent to the channel where the command is called.
![image](https://user-images.githubusercontent.com/36454654/99287970-dc093980-2832-11eb-9628-820a2e8572d8.png)
