### PR TITLE
Remove response sheet on event removal

### DIFF
--- a/DiscordBot.DataAccess/EventsSheetsService.cs
+++ b/DiscordBot.DataAccess/EventsSheetsService.cs
@@ -181,7 +181,11 @@ namespace DiscordBot.DataAccess
 
             var requestParameters = new BatchUpdateSpreadsheetRequest()
             {
-                Requests = new[] { SheetsServiceRequestsHelper.RemoveEvent(metadataSheetId, rowNumber) }
+                Requests = new[]
+                {
+                    SheetsServiceRequestsHelper.RemoveEventMetadata(metadataSheetId, rowNumber),
+                    SheetsServiceRequestsHelper.RemoveEventResponses(responseSheetId)
+                }
             };
 
             var request = sheetsService.Spreadsheets.BatchUpdate(requestParameters, spreadsheetId);

--- a/DiscordBot.DataAccess/SheetNotFoundException.cs
+++ b/DiscordBot.DataAccess/SheetNotFoundException.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace DiscordBot.DataAccess
+{
+    class SheetNotFoundException : Exception
+    {
+    }
+}

--- a/DiscordBot.DataAccess/SheetsServiceRequestsHelper.cs
+++ b/DiscordBot.DataAccess/SheetsServiceRequestsHelper.cs
@@ -85,7 +85,7 @@ namespace DiscordBot.DataAccess
             return new Request() { AppendCells = addResponseColumns };
         }
 
-        public static Request RemoveEvent(int metadataSheetId, int rowNumber)
+        public static Request RemoveEventMetadata(int metadataSheetId, int rowNumber)
         {
             return new Request()
             {
@@ -98,6 +98,17 @@ namespace DiscordBot.DataAccess
                         StartIndex = rowNumber - 1,
                         EndIndex = rowNumber
                     }
+                }
+            };
+        }
+
+        public static Request RemoveEventResponses(int responseSheetId)
+        {
+            return new Request()
+            {
+                DeleteSheet = new DeleteSheetRequest()
+                {
+                    SheetId = responseSheetId
                 }
             };
         }


### PR DESCRIPTION
Also generalise the `sheetId` lookup (where sheet in this context means a single sheet among multiple in a spreadsheet document). 