### PR TITLE
Migrate from 3.x to 4.x

### DIFF
--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -8,10 +8,11 @@ using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
 using DSharpPlus.Interactivity;
+using DSharpPlus.Interactivity.Extensions;
 
 namespace DiscordBot.Commands
 {
-    internal class EventCommands
+    internal class EventCommands : BaseCommandModule
     {
         private static readonly string[] EventOperations =
         {
@@ -35,12 +36,18 @@ namespace DiscordBot.Commands
             "yes",
             "no"
         };
+        public IEventsSheetsService EventsSheetsService { private get; set; }
+
+        public EventCommands(IEventsSheetsService eventsSheetsService)
+        {
+            EventsSheetsService = eventsSheetsService;
+        }
 
         [Command("event")]
         [Description("Initiates the wizard for event-related actions")]
         public async Task Event(CommandContext context)
         {
-            var interactivity = context.Client.GetInteractivityModule();
+            var interactivity = context.Client.GetInteractivity();
 
             await context.RespondAsync(
                 $"{context.Member.Mention} - choose one of the actions below or answer ``stop`` to cancel. (time out in 30s)\n" +
@@ -64,7 +71,7 @@ namespace DiscordBot.Commands
                     await CreateEvent(context, interactivity);
                     break;
                 case "list":
-                    await ListEvents(context, interactivity);
+                    await ListEvents(context);
                     break;
                 case "remove":
                     await RemoveEvent(context, interactivity);
@@ -81,7 +88,7 @@ namespace DiscordBot.Commands
             }
         }
 
-        public async Task CreateEvent(CommandContext context, InteractivityModule interactivity)
+        public async Task CreateEvent(CommandContext context, InteractivityExtension interactivity)
         {
             await context.RespondAsync($"{context.Member.Mention} - what is the name of the event?");
             var eventName = await GetUserResponse(context, interactivity);
@@ -104,9 +111,7 @@ namespace DiscordBot.Commands
                 return;
             }
 
-            var eventsSheetService = context.Dependencies.GetDependency<IEventsSheetsService>();
-
-            await eventsSheetService.AddEventAsync(eventName, eventDescription, eventTime.Value.DateTime);
+            await EventsSheetsService.AddEventAsync(eventName, eventDescription, eventTime.Value.DateTime);
 
             var eventEmbed = new DiscordEmbedBuilder
             {
@@ -119,7 +124,7 @@ namespace DiscordBot.Commands
             await context.RespondAsync(embed: eventEmbed);
         }
 
-        public async Task RemoveEvent(CommandContext context, InteractivityModule interactivity)
+        public async Task RemoveEvent(CommandContext context, InteractivityExtension interactivity)
         {
             await context.RespondAsync($"{context.Member.Mention} - what is the event key? (use the ``list`` option to find out)");
             var eventKey = await GetUserIntResponse(context, interactivity);
@@ -145,7 +150,7 @@ namespace DiscordBot.Commands
 
             try
             {
-                await context.Dependencies.GetDependency<IEventsSheetsService>()
+                await EventsSheetsService
                     .RemoveEventAsync(eventKey.Value);
                 await context.RespondAsync($"{context.Member.Mention} - poof! It's gone.");
             }
@@ -155,7 +160,7 @@ namespace DiscordBot.Commands
             }
         }
 
-        public async Task ShowEvent(CommandContext context, InteractivityModule interactivity)
+        public async Task ShowEvent(CommandContext context, InteractivityExtension interactivity)
         {
             await context.RespondAsync($"{context.Member.Mention} - what is the event key? (use the ``list`` option to find out)");
             var eventKey = await GetUserIntResponse(context, interactivity);
@@ -173,10 +178,9 @@ namespace DiscordBot.Commands
             await context.RespondAsync($"{context.Member.Mention} - here is the event", embed: eventEmbed);
         }
   
-        public async Task ListEvents(CommandContext context, InteractivityModule interactivity)
+        public async Task ListEvents(CommandContext context)
         {
-            var eventsSheetsService = context.Dependencies.GetDependency<IEventsSheetsService>();
-            var eventsList = await eventsSheetsService.ListEventsAsync();
+            var eventsList = await EventsSheetsService.ListEventsAsync();
 
             var eventsListEmbed = new DiscordEmbedBuilder
             {
@@ -194,7 +198,7 @@ namespace DiscordBot.Commands
             await context.RespondAsync($"{context.Member.Mention} - here are all created events.", embed: eventsListEmbed);
         }
 
-        public async Task EditEvent(CommandContext context, InteractivityModule interactivity)
+        public async Task EditEvent(CommandContext context, InteractivityExtension interactivity)
         {
             await context.RespondAsync($"{context.Member.Mention} - what is the event key? (use the ``list`` option to find out)");
             var eventKey = await GetUserIntResponse(context, interactivity);
@@ -221,7 +225,7 @@ namespace DiscordBot.Commands
             await EditEventField(context, interactivity, eventKey.Value, editField, eventEmbed);
         }
 
-        private static async Task CreateSignupSheet(CommandContext context, InteractivityModule interactivity)
+        private async Task CreateSignupSheet(CommandContext context, InteractivityExtension interactivity)
         {
             await context.RespondAsync($"{context.Member.Mention} - what is the event key? (use the ``list`` option to find out)");
             var eventKey = await GetUserIntResponse(context, interactivity);
@@ -246,17 +250,16 @@ namespace DiscordBot.Commands
             await SendSignupMessage(context, eventKey.Value);
         }
 
-        private static async Task SendSignupMessage(CommandContext context, int eventKey)
+        private async Task SendSignupMessage(CommandContext context, int eventKey)
         { 
-            var eventsSheetsService = context.Dependencies.GetDependency<IEventsSheetsService>();
-            var discordEvent = await eventsSheetsService.GetEventAsync(eventKey);
+            var discordEvent = await EventsSheetsService.GetEventAsync(eventKey);
 
-            var signupsByResponse = await eventsSheetsService.GetSignupsByResponseAsync(eventKey);
+            var signupsByResponse = await EventsSheetsService.GetSignupsByResponseAsync(eventKey);
 
             var signupEmbed = GetSignupEmbed(discordEvent, signupsByResponse);
 
             var signupMessage = await context.RespondAsync($"Signups are open for __**{discordEvent.Name}**__!", embed: signupEmbed);
-            await eventsSheetsService.AddMessageIdToEventAsync(eventKey, signupMessage.Id);
+            await EventsSheetsService.AddMessageIdToEventAsync(eventKey, signupMessage.Id);
 
             foreach (var response in signupsByResponse.Keys)
             {
@@ -264,7 +267,7 @@ namespace DiscordBot.Commands
             }
         }
 
-        private static Dictionary<ulong, IEnumerable<EventResponse>> GetResponsesByUser(
+        private Dictionary<ulong, IEnumerable<EventResponse>> GetResponsesByUser(
             Dictionary<EventResponse, IEnumerable<ulong>> signupsByResponse)
         {
             var signupsByUser = new Dictionary<ulong, IEnumerable<EventResponse>>();
@@ -285,7 +288,7 @@ namespace DiscordBot.Commands
             return signupsByUser;
         }
 
-        private static DiscordEmbedBuilder GetSignupEmbed(
+        private DiscordEmbedBuilder GetSignupEmbed(
             DiscordEvent discordEvent,
             Dictionary<EventResponse, IEnumerable<ulong>> signupsByResponse)
         {
@@ -325,9 +328,9 @@ namespace DiscordBot.Commands
             return signupEmbed;
         }
 
-        private static async Task EditEventField(
+        private async Task EditEventField(
             CommandContext context,
-            InteractivityModule interactivity,
+            InteractivityExtension interactivity,
             int eventKey,
             string editField,
             DiscordEmbedBuilder eventEmbed)
@@ -370,7 +373,7 @@ namespace DiscordBot.Commands
             }
         }
 
-        private static async Task TryEditEvent(
+        private async Task TryEditEvent(
             CommandContext context,
             int eventKey,
             DiscordEmbedBuilder eventEmbed,
@@ -380,8 +383,7 @@ namespace DiscordBot.Commands
         {
             try
             {
-                var eventsSheetService = context.Dependencies.GetDependency<IEventsSheetsService>();
-                await eventsSheetService.EditEventAsync(eventKey, newDescription, newName, newTime);
+                await EventsSheetsService.EditEventAsync(eventKey, newDescription, newName, newTime);
                 await context.RespondAsync($"{context.Member.Mention} - changes saved!", embed: eventEmbed);
             }
             catch (EventNotFoundException)
@@ -390,13 +392,11 @@ namespace DiscordBot.Commands
             }
         }
 
-        private static async Task<DiscordEmbedBuilder?> GetEventEmbed(CommandContext context, int eventKey)
+        private async Task<DiscordEmbedBuilder?> GetEventEmbed(CommandContext context, int eventKey)
         {
-            var eventsSheetService = context.Dependencies.GetDependency<IEventsSheetsService>();
-            
             try
             {
-                var discordEvent = await eventsSheetService.GetEventAsync(eventKey);
+                var discordEvent = await EventsSheetsService.GetEventAsync(eventKey);
 
                 return new DiscordEmbedBuilder
                 {
@@ -412,16 +412,16 @@ namespace DiscordBot.Commands
             }
         }
 
-        private static async Task<string?> GetUserResponse(
+        private async Task<string?> GetUserResponse(
             CommandContext context,
-            InteractivityModule interactivity,
+            InteractivityExtension interactivity,
             string[]? validStrings = null)
         {
             var response = interactivity.WaitForMessageAsync(
                 message =>
                     IsValidResponse(message, context, validStrings),
                 TimeSpan.FromSeconds(30)
-            ).Result?.Message.Content;
+            ).Result.Result.Content;
 
             switch (response)
             {
@@ -436,15 +436,15 @@ namespace DiscordBot.Commands
             return response;
         }
 
-        private static async Task<bool?> GetUserConfirmation(
+        private async Task<bool?> GetUserConfirmation(
             CommandContext context,
-            InteractivityModule interactivity)
+            InteractivityExtension interactivity)
         {
             var response = interactivity.WaitForMessageAsync(
                 message =>
                     IsValidResponse(message, context, ConfirmationResponses),
                 TimeSpan.FromSeconds(30)
-            ).Result?.Message.Content;
+            ).Result.Result.Content;
 
             switch (response)
             {
@@ -459,9 +459,9 @@ namespace DiscordBot.Commands
             return response == "yes";
         }
 
-        private static async Task<DateTimeOffset?> GetUserTimeResponse(
+        private async Task<DateTimeOffset?> GetUserTimeResponse(
             CommandContext context,
-            InteractivityModule interactivity)
+            InteractivityExtension interactivity)
         {
             var response = await GetUserResponse(context, interactivity);
 
@@ -481,9 +481,9 @@ namespace DiscordBot.Commands
             }
         }
 
-        private static async Task<int?> GetUserIntResponse(
+        private async Task<int?> GetUserIntResponse(
             CommandContext context,
-            InteractivityModule interactivity)
+            InteractivityExtension interactivity)
         {
             var response = await GetUserResponse(context, interactivity);
 
@@ -503,7 +503,7 @@ namespace DiscordBot.Commands
             }
         }
 
-        private static bool IsValidResponse(DiscordMessage response, CommandContext context, string[]? validStrings)
+        private bool IsValidResponse(DiscordMessage response, CommandContext context, string[]? validStrings)
         {
             return context.User.Id == response.Author.Id &&
                    context.Channel == response.Channel &&

--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -36,11 +36,12 @@ namespace DiscordBot.Commands
             "yes",
             "no"
         };
-        public IEventsSheetsService EventsSheetsService { private get; set; }
+
+        private readonly IEventsSheetsService eventsSheetsService;
 
         public EventCommands(IEventsSheetsService eventsSheetsService)
         {
-            EventsSheetsService = eventsSheetsService;
+            this.eventsSheetsService = eventsSheetsService;
         }
 
         [Command("event")]
@@ -111,7 +112,7 @@ namespace DiscordBot.Commands
                 return;
             }
 
-            await EventsSheetsService.AddEventAsync(eventName, eventDescription, eventTime.Value.DateTime);
+            await eventsSheetsService.AddEventAsync(eventName, eventDescription, eventTime.Value.DateTime);
 
             var eventEmbed = new DiscordEmbedBuilder
             {
@@ -150,7 +151,7 @@ namespace DiscordBot.Commands
 
             try
             {
-                await EventsSheetsService
+                await eventsSheetsService
                     .RemoveEventAsync(eventKey.Value);
                 await context.RespondAsync($"{context.Member.Mention} - poof! It's gone.");
             }
@@ -180,7 +181,7 @@ namespace DiscordBot.Commands
   
         public async Task ListEvents(CommandContext context)
         {
-            var eventsList = await EventsSheetsService.ListEventsAsync();
+            var eventsList = await eventsSheetsService.ListEventsAsync();
 
             var eventsListEmbed = new DiscordEmbedBuilder
             {
@@ -252,14 +253,14 @@ namespace DiscordBot.Commands
 
         private async Task SendSignupMessage(CommandContext context, int eventKey)
         { 
-            var discordEvent = await EventsSheetsService.GetEventAsync(eventKey);
+            var discordEvent = await eventsSheetsService.GetEventAsync(eventKey);
 
-            var signupsByResponse = await EventsSheetsService.GetSignupsByResponseAsync(eventKey);
+            var signupsByResponse = await eventsSheetsService.GetSignupsByResponseAsync(eventKey);
 
             var signupEmbed = GetSignupEmbed(discordEvent, signupsByResponse);
 
             var signupMessage = await context.RespondAsync($"Signups are open for __**{discordEvent.Name}**__!", embed: signupEmbed);
-            await EventsSheetsService.AddMessageIdToEventAsync(eventKey, signupMessage.Id);
+            await eventsSheetsService.AddMessageIdToEventAsync(eventKey, signupMessage.Id);
 
             foreach (var response in signupsByResponse.Keys)
             {
@@ -383,7 +384,7 @@ namespace DiscordBot.Commands
         {
             try
             {
-                await EventsSheetsService.EditEventAsync(eventKey, newDescription, newName, newTime);
+                await eventsSheetsService.EditEventAsync(eventKey, newDescription, newName, newTime);
                 await context.RespondAsync($"{context.Member.Mention} - changes saved!", embed: eventEmbed);
             }
             catch (EventNotFoundException)
@@ -396,7 +397,7 @@ namespace DiscordBot.Commands
         {
             try
             {
-                var discordEvent = await EventsSheetsService.GetEventAsync(eventKey);
+                var discordEvent = await eventsSheetsService.GetEventAsync(eventKey);
 
                 return new DiscordEmbedBuilder
                 {

--- a/DiscordBot/DiscordBot.csproj
+++ b/DiscordBot/DiscordBot.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="4.0.0-nightly-00753" />
-    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-nightly-00753" />
-    <PackageReference Include="DSharpPlus.Interactivity" Version="4.0.0-nightly-00753" />
+    <PackageReference Include="DSharpPlus" Version="4.0.0-rc1" />
+    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-rc1" />
+    <PackageReference Include="DSharpPlus.Interactivity" Version="4.0.0-rc1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DiscordBot.DataAccess\DiscordBot.DataAccess.csproj" />

--- a/DiscordBot/DiscordBot.csproj
+++ b/DiscordBot/DiscordBot.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="3.2.3" />
-    <PackageReference Include="DSharpPlus.CommandsNext" Version="3.2.3" />
-    <PackageReference Include="DSharpPlus.Interactivity" Version="3.2.3" />
+    <PackageReference Include="DSharpPlus" Version="4.0.0-nightly-00753" />
+    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-nightly-00753" />
+    <PackageReference Include="DSharpPlus.Interactivity" Version="4.0.0-nightly-00753" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DiscordBot.DataAccess\DiscordBot.DataAccess.csproj" />

--- a/DiscordBot/Program.cs
+++ b/DiscordBot/Program.cs
@@ -5,6 +5,8 @@ using DiscordBot.DataAccess;
 using DSharpPlus;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.Interactivity;
+using DSharpPlus.Interactivity.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DiscordBot
 {
@@ -20,19 +22,17 @@ namespace DiscordBot
             var discord = new DiscordClient(new DiscordConfiguration
             {
                 Token = Environment.GetEnvironmentVariable("RELEASE_BOT_TOKEN"),
-                TokenType = TokenType.Bot,
-                UseInternalLogHandler = true,
-                LogLevel = LogLevel.Debug
+                TokenType = TokenType.Bot
             });
 
-            using var builder = new DependencyCollectionBuilder();
-            builder.AddInstance<IEventsSheetsService>(new EventsSheetsService());
-            var dependencies = builder.Build();
-            
+            var services = new ServiceCollection()
+                .AddSingleton<IEventsSheetsService>(new EventsSheetsService())
+                .BuildServiceProvider();
+
             var commands = discord.UseCommandsNext(new CommandsNextConfiguration
             {
-                StringPrefix = "?",
-                Dependencies = dependencies
+                StringPrefixes = new [] { "?" },
+                Services = services
             });
 
             commands.RegisterCommands<EventCommands>();


### PR DESCRIPTION
Turns out 3.x is almost obsolete so we've migrated the bot to the 4.x version.

Main changes:

- The service can now be assigned in the constructor and therefore doesn't need to be gotten every time it's needed
- Some classes were renamed
- Some class methods were renamed