### PR TITLE
Change appearence of embeds

### DIFF
--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -134,13 +134,11 @@ namespace DiscordBot.Commands
 
             var eventEmbed = new DiscordEmbedBuilder
             {
-                Title = eventName,
-                Description = eventDescription,
-                Color = new DiscordColor(0xFFFFFF),
-                Timestamp = eventTime
+                Title = $"{eventName} - {eventTime:ddd dd MMM yyyy @ h:mm tt}",
+                Description = eventDescription
             };
 
-            await context.RespondAsync(embed: eventEmbed);
+            await context.RespondAsync($"{context.Member.Mention} - your event has been added!", embed: eventEmbed);
         }
 
         [Command("remove")]
@@ -361,9 +359,12 @@ namespace DiscordBot.Commands
 
                 return new DiscordEmbedBuilder
                 {
-                    Title = discordEvent.Name,
+                    Title = $"{discordEvent.Name} - {discordEvent.Time:ddd dd MMM yyyy @ h:mm tt}",
                     Description = discordEvent.Description,
-                    Timestamp = new DateTimeOffset(discordEvent.Time)
+                    Footer = new DiscordEmbedBuilder.EmbedFooter
+                    {
+                        Text = $"event key: {discordEvent.Key}"
+                    }
                 };
             }
             catch (EventNotFoundException)


### PR DESCRIPTION
Updated the preview for starting signups and result from the show command:
Before:
![image](https://user-images.githubusercontent.com/36454654/99647804-2ca6af80-2a4a-11eb-873d-354361c3068a.png)

After:
![image](https://user-images.githubusercontent.com/36454654/99647845-39c39e80-2a4a-11eb-999f-13dfccd23e4e.png)

The create event confirmation has also been changed but lacks the event key to conserve Sheets API calls.