### PR TITLE
Add interface for batching event responses

### DIFF
--- a/DiscordBot.DataAccess/EventsSheetsService.cs
+++ b/DiscordBot.DataAccess/EventsSheetsService.cs
@@ -27,10 +27,8 @@ namespace DiscordBot.DataAccess
         Task<DiscordEvent> GetEventFromMessageIdAsync(ulong messageId);
         Task<IEnumerable<DiscordEvent>> ListEventsAsync();
 
-        Task AddResponseForUserAsync(int eventKey, ulong userId, string responseEmoji);
         Task AddResponseBatchAsync(IEnumerable<ResponseReaction> reactions);
         Task ClearResponseBatchAsync(IEnumerable<ResponseReaction> reactions);
-        Task ClearResponsesForUserAsync(int eventKey, ulong userId);
 
         Task<Dictionary<EventResponse, IEnumerable<ulong>>> GetSignupsByResponseAsync(int eventId);
     }
@@ -147,19 +145,6 @@ namespace DiscordBot.DataAccess
             }
         }
 
-        public async Task AddResponseForUserAsync(int eventKey, ulong userId, string responseEmoji)
-        {
-            try
-            {
-                await sheetsSemaphore.WaitAsync();
-                await eventsSheetsService.AddResponseForUserAsync(eventKey, userId, responseEmoji);
-            }
-            finally
-            {
-                sheetsSemaphore.Release();
-            }
-        }
-
         public async Task AddResponseBatchAsync(IEnumerable<ResponseReaction> reactions)
         {
             try
@@ -179,19 +164,6 @@ namespace DiscordBot.DataAccess
             {
                 await sheetsSemaphore.WaitAsync();
                 await eventsSheetsService.ClearResponseBatchAsync(reactions);
-            }
-            finally
-            {
-                sheetsSemaphore.Release();
-            }
-        }
-
-        public async Task ClearResponsesForUserAsync(int eventKey, ulong userId)
-        {
-            try
-            {
-                await sheetsSemaphore.WaitAsync();
-                await eventsSheetsService.ClearResponsesForUserAsync(eventKey, userId);
             }
             finally
             {

--- a/DiscordBot.DataAccess/EventsSheetsService.cs
+++ b/DiscordBot.DataAccess/EventsSheetsService.cs
@@ -28,6 +28,8 @@ namespace DiscordBot.DataAccess
         Task<IEnumerable<DiscordEvent>> ListEventsAsync();
 
         Task AddResponseForUserAsync(int eventKey, ulong userId, string responseEmoji);
+        Task AddResponseBatchAsync(IEnumerable<ResponseReaction> reactions);
+        Task ClearResponseBatchAsync(IEnumerable<ResponseReaction> reactions);
         Task ClearResponsesForUserAsync(int eventKey, ulong userId);
 
         Task<Dictionary<EventResponse, IEnumerable<ulong>>> GetSignupsByResponseAsync(int eventId);
@@ -151,6 +153,32 @@ namespace DiscordBot.DataAccess
             {
                 await sheetsSemaphore.WaitAsync();
                 await eventsSheetsService.AddResponseForUserAsync(eventKey, userId, responseEmoji);
+            }
+            finally
+            {
+                sheetsSemaphore.Release();
+            }
+        }
+
+        public async Task AddResponseBatchAsync(IEnumerable<ResponseReaction> reactions)
+        {
+            try
+            {
+                await sheetsSemaphore.WaitAsync();
+                await eventsSheetsService.AddResponseBatchAsync(reactions);
+            }
+            finally
+            {
+                sheetsSemaphore.Release();
+            }
+        }
+
+        public async Task ClearResponseBatchAsync(IEnumerable<ResponseReaction> reactions)
+        {
+            try
+            {
+                await sheetsSemaphore.WaitAsync();
+                await eventsSheetsService.ClearResponseBatchAsync(reactions);
             }
             finally
             {

--- a/DiscordBot.DataAccess/EventsSheetsService.cs
+++ b/DiscordBot.DataAccess/EventsSheetsService.cs
@@ -27,8 +27,10 @@ namespace DiscordBot.DataAccess
         Task<DiscordEvent> GetEventFromMessageIdAsync(ulong messageId);
         Task<IEnumerable<DiscordEvent>> ListEventsAsync();
 
+        Task AddResponseForUserAsync(int eventKey, ulong userId, string responseEmoji);
         Task AddResponseBatchAsync(IEnumerable<ResponseReaction> reactions);
         Task ClearResponseBatchAsync(IEnumerable<ResponseReaction> reactions);
+        Task ClearResponsesForUserAsync(int eventKey, ulong userId);
 
         Task<Dictionary<EventResponse, IEnumerable<ulong>>> GetSignupsByResponseAsync(int eventId);
     }
@@ -145,6 +147,19 @@ namespace DiscordBot.DataAccess
             }
         }
 
+        public async Task AddResponseForUserAsync(int eventKey, ulong userId, string responseEmoji)
+        {
+            try
+            {
+                await sheetsSemaphore.WaitAsync();
+                await eventsSheetsService.AddResponseForUserAsync(eventKey, userId, responseEmoji);
+            }
+            finally
+            {
+                sheetsSemaphore.Release();
+            }
+        }
+
         public async Task AddResponseBatchAsync(IEnumerable<ResponseReaction> reactions)
         {
             try
@@ -164,6 +179,19 @@ namespace DiscordBot.DataAccess
             {
                 await sheetsSemaphore.WaitAsync();
                 await eventsSheetsService.ClearResponseBatchAsync(reactions);
+            }
+            finally
+            {
+                sheetsSemaphore.Release();
+            }
+        }
+
+        public async Task ClearResponsesForUserAsync(int eventKey, ulong userId)
+        {
+            try
+            {
+                await sheetsSemaphore.WaitAsync();
+                await eventsSheetsService.ClearResponsesForUserAsync(eventKey, userId);
             }
             finally
             {

--- a/DiscordBot.DataAccess/Models/ResponseReaction.cs
+++ b/DiscordBot.DataAccess/Models/ResponseReaction.cs
@@ -1,0 +1,16 @@
+﻿namespace DiscordBot.DataAccess.Models
+{
+    public class ResponseReaction
+    {
+        public ulong MessageId { get; }
+        public ulong UserId { get; }
+        public string Emoji { get; }
+
+        public ResponseReaction(ulong messageId, ulong userId, string emoji)
+        {
+            MessageId = messageId;
+            UserId = userId;
+            Emoji = emoji;
+        }
+    }
+}

--- a/DiscordBot.DataAccess/UnsafeEventsSheetsService.cs
+++ b/DiscordBot.DataAccess/UnsafeEventsSheetsService.cs
@@ -262,6 +262,16 @@ namespace DiscordBot.DataAccess
             }
         }
 
+#pragma warning disable 1998 // Turn off compiler warning for synchronous unimplemented methods
+        public async Task AddResponseBatchAsync(IEnumerable<ResponseReaction> reactions)
+        {
+        }
+
+        public async Task ClearResponseBatchAsync(IEnumerable<ResponseReaction> reactions)
+        {
+        }
+#pragma warning restore 1998
+
         public async Task ClearResponsesForUserAsync(int eventKey, ulong userId)
         {
             var rowNumber = await GetResponseRowNumberAsync(eventKey, userId);

--- a/DiscordBot.DataAccess/UnsafeEventsSheetsService.cs
+++ b/DiscordBot.DataAccess/UnsafeEventsSheetsService.cs
@@ -236,6 +236,32 @@ namespace DiscordBot.DataAccess
             }
         }
 
+        public async Task AddResponseForUserAsync(int eventKey, ulong userId, string responseEmoji)
+        {
+            var responseRowTask = GetResponseRowNumberAsync(eventKey, userId);
+            var responseColumnsTask = GetEventResponseOptionsAsync(eventKey);
+
+            await Task.WhenAll(responseRowTask, responseColumnsTask);
+            var responseRow = responseRowTask.Result;
+            var responseColumns = responseColumnsTask.Result;
+
+            if (!responseColumns.Any(response => response.Emoji == responseEmoji))
+            {
+                throw new ResponseNotFoundException(
+                    $"Response {responseEmoji} is not recognised for event {eventKey}"
+                );
+            }
+
+            if (responseRow == null)
+            {
+                await AddResponseForNewUserAsync(eventKey, userId, responseEmoji, responseColumns);
+            }
+            else
+            {
+                await AddResponseForExistingUserAsync(eventKey, responseRow.Value, responseEmoji, responseColumns);
+            }
+        }
+
 #pragma warning disable 1998 // Turn off compiler warning for synchronous unimplemented methods
         public async Task AddResponseBatchAsync(IEnumerable<ResponseReaction> reactions)
         {
@@ -245,6 +271,27 @@ namespace DiscordBot.DataAccess
         {
         }
 #pragma warning restore 1998
+
+        public async Task ClearResponsesForUserAsync(int eventKey, ulong userId)
+        {
+            var rowNumber = await GetResponseRowNumberAsync(eventKey, userId);
+
+            // If the user has already cleared their responses/never signed up in the first place
+            if (rowNumber == null)
+            {
+                return;
+            }
+
+            var responseSheetId = await GetSheetIdFromTitleAsync(eventKey.ToString());
+
+            var requestParameters = new BatchUpdateSpreadsheetRequest()
+            {
+                Requests = new[] { SheetsServiceRequestsHelper.RemoveRow(responseSheetId, rowNumber.Value) }
+            };
+
+            var request = sheetsService.Spreadsheets.BatchUpdate(requestParameters, spreadsheetId);
+            await SheetsServiceRequestsHelper.ExecuteRequestsWithRetriesAsync(request);
+        }
 
         public async Task<Dictionary<EventResponse, IEnumerable<ulong>>> GetSignupsByResponseAsync(int eventId)
         {

--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -15,6 +15,8 @@ namespace DiscordBot.Commands
     [RequireRoles(RoleCheckMode.All, "Bot Whisperer")]
     internal class EventCommands : BaseCommandModule
     {
+        public const string ClearReaction = ":no_entry_sign:";
+
         private static readonly string[] EventOperations =
         {
             "create",
@@ -287,7 +289,7 @@ namespace DiscordBot.Commands
                 await signupMessage.CreateReactionAsync(DiscordEmoji.FromName(context.Client, response.Emoji));
             }
 
-            await signupMessage.CreateReactionAsync(DiscordEmoji.FromName(context.Client, ":no_entry_sign:"));
+            await signupMessage.CreateReactionAsync(DiscordEmoji.FromName(context.Client, ClearReaction));
         }
 
         private async Task EditEventField(

--- a/DiscordBot/Commands/ReactionBuffer.cs
+++ b/DiscordBot/Commands/ReactionBuffer.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DiscordBot.DataAccess;
+using DiscordBot.DataAccess.Models;
+using DSharpPlus;
+
+namespace DiscordBot.Commands
+{
+    internal enum ReactionBufferState
+    {
+        Ready,
+        Collecting
+    }
+
+    internal class ReactionBuffer
+    {
+        private const int bufferDelayMilliseconds = 10 * 1000;
+
+        private readonly BlockingCollection<ResponseReaction> buffer;
+        private readonly SemaphoreSlim bufferStateLock;
+        private ReactionBufferState state;
+
+        private readonly IEventsSheetsService eventsSheetsService;
+        private readonly DiscordClient client;
+
+        public ReactionBuffer(IEventsSheetsService eventsSheetsService, DiscordClient client)
+        {
+            buffer = new BlockingCollection<ResponseReaction>();
+            bufferStateLock = new SemaphoreSlim(1);
+            state = ReactionBufferState.Ready;
+
+            this.eventsSheetsService = eventsSheetsService;
+            this.client = client;
+        }
+
+        public async Task AddReaction(ResponseReaction reaction)
+        {
+            // Invariants: you may only read/write from the state and buffer variables if you hold
+            // the bufferStateLock semaphore
+
+            await bufferStateLock.WaitAsync();
+            buffer.Add(reaction);
+
+            // If another thread is collecting reactions to process, we don't need to
+            if (state == ReactionBufferState.Collecting)
+            {
+                bufferStateLock.Release();
+                return;
+            }
+
+            // Else we should start collecting reactions, wait some time for more to come in
+            state = ReactionBufferState.Collecting;
+            bufferStateLock.Release();
+            await Task.Delay(bufferDelayMilliseconds);
+
+            // Lock the list, get and empty its contents to be processed
+            await bufferStateLock.WaitAsync();
+            var reactions = buffer.GetConsumingEnumerable().ToList();
+            state = ReactionBufferState.Ready;
+            bufferStateLock.Release();
+
+            await ProcessReactions(reactions);
+        }
+
+        private async Task ProcessReactions(IEnumerable<ResponseReaction> reactions)
+        {
+            var distinctReactions = reactions.Distinct().ToList();
+
+            var addReactions = distinctReactions.Where(reaction => reaction.Emoji != EventCommands.ClearReaction);
+            await eventsSheetsService.AddResponseBatchAsync(addReactions);
+
+            var clearReactions = distinctReactions.Where(reaction => reaction.Emoji == EventCommands.ClearReaction);
+            await eventsSheetsService.ClearResponseBatchAsync(clearReactions);
+
+            // Send some DMs... TODO by Frank
+        }
+    }
+}

--- a/DiscordBot/Program.cs
+++ b/DiscordBot/Program.cs
@@ -89,10 +89,10 @@ namespace DiscordBot
 
             switch (eventArguments.Emoji.GetDiscordName())
             {
-                case (EventCommands.ClearReaction):
+                case (":arrows_counterclockwise:"):
                     await UpdateSignupMessage(eventArguments, discordEvent, eventsSheetsService);
                     break;
-                case (":no_entry_sign:"):
+                case (EventCommands.ClearReaction):
                     await eventsSheetsService.ClearResponsesForUserAsync(discordEvent.Key, eventArguments.User.Id);
                     await client.SendMessageAsync(
                         dmChannel,

--- a/DiscordBot/Program.cs
+++ b/DiscordBot/Program.cs
@@ -88,7 +88,7 @@ namespace DiscordBot
                 .GetMemberAsync(eventArguments.User.Id).Result
                 .CreateDmChannelAsync();
 
-            if (eventArguments.Emoji.GetDiscordName() == ":no_entry_sign:")
+            if (eventArguments.Emoji.GetDiscordName() == EventCommands.ClearReaction)
             {
                 await eventsSheetsService.ClearResponsesForUserAsync(discordEvent.Key, eventArguments.User.Id);
                 await client.SendMessageAsync(dmChannel, $"You've signed off {discordEvent.Name}.");


### PR DESCRIPTION
Add a thread-safe buffer for storing reactions as they come in, and
process them up to every 10s.

Add an interface to the EventsSheetsService to process these batches
of requests. Add a model to store all information needed in a reaction:
a message (ie event) ID, a user ID and a reaction emoji (response
type).

I will implement the EventsSheetsService in another PR, and Frank
will plumb this into the Discord front end. 