### PR TITLE
Add response set options on event creation

### DIFF
--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -161,16 +161,14 @@ namespace DiscordBot.Commands
                 Title = "Response options"
             };
 
-
-            var i = 0;
-            foreach (var responseSet in ResponseSets)
+            for (var i = 0; i < ResponseSets.Length; i++)
             {
+                var responseSet = ResponseSets[i];
                 var responseSetString = string.Join(
                     ", ",
                     responseSet.Select(response => $"{response.ResponseName} - {response.Emoji}")
                 );
                 responseEmbed.AddField($"Response set {i}", responseSetString);
-                i += 1;
             }
 
             await context.RespondAsync(
@@ -189,7 +187,7 @@ namespace DiscordBot.Commands
             DateTime eventTime,
             int? responseSetIndex)
         {
-            if (responseSetIndex == null || responseSetIndex.Value >= ResponseSets.Length)
+            if (responseSetIndex == null || responseSetIndex.Value >= ResponseSets.Length || responseSetIndex.Value < 0)
             {
                 await context.RespondAsync("Invalid response set number");
                 return;

--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DiscordBot.DataAccess;
@@ -163,10 +162,9 @@ namespace DiscordBot.Commands
 
             for (var i = 0; i < ResponseSets.Length; i++)
             {
-                var responseSet = ResponseSets[i];
                 var responseSetString = string.Join(
                     ", ",
-                    responseSet.Select(response => $"{response.ResponseName} - {response.Emoji}")
+                    ResponseSets[i].Select(response => $"{response.ResponseName} - {response.Emoji}")
                 );
                 responseEmbed.AddField($"Response set {i}", responseSetString);
             }


### PR DESCRIPTION
You can now choose between a set of hard-coded response sets for your signup as demonstrated in the image below

![image](https://user-images.githubusercontent.com/44266225/99678812-20831800-2a73-11eb-93ba-a0215c63333a.png)
