### PR TITLE
Add button refresh and remove automatic refresh

### DIFF
--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -329,8 +329,8 @@ namespace DiscordBot.Commands
             {
                 await signupMessage.CreateReactionAsync(DiscordEmoji.FromName(context.Client, response.Emoji));
             }
-
             await signupMessage.CreateReactionAsync(DiscordEmoji.FromName(context.Client, ":no_entry_sign:"));
+            await signupMessage.CreateReactionAsync(DiscordEmoji.FromName(context.Client, ":arrows_counterclockwise:"));
         }
 
         private async Task EditEventField(

--- a/DiscordBot/Program.cs
+++ b/DiscordBot/Program.cs
@@ -100,14 +100,14 @@ namespace DiscordBot
                     );
                     break;
                 default:
-                    await AddReaction(client, eventArguments, discordEvent, dmChannel, eventsSheetsService);
+                    await AddResponse(client, eventArguments, discordEvent, dmChannel, eventsSheetsService);
                     break;
             }
 
             await eventArguments.Message.DeleteReactionAsync(eventArguments.Emoji, eventArguments.User);
         }
 
-        private static async Task AddReaction(
+        private static async Task AddResponse(
             DiscordClient client,
             MessageReactionAddEventArgs eventArguments,
             DiscordEvent discordEvent,
@@ -124,6 +124,7 @@ namespace DiscordBot
             }
             catch (ResponseNotFoundException)
             {
+                return;
             }
 
             await client.SendMessageAsync(


### PR DESCRIPTION
The signup sheet no longer refreshes upon someone signing on/off the event.

A refresh button has been added to the signup sheet to manually refresh the sheet.
![image](https://user-images.githubusercontent.com/36454654/99686036-17964480-2a7b-11eb-83bd-d8d7165b14e1.png)
