### PR TITLE
Update front end to batch responses

### DIFF
--- a/DiscordBot/Commands/EventCommands.cs
+++ b/DiscordBot/Commands/EventCommands.cs
@@ -19,7 +19,7 @@ namespace DiscordBot.Commands
         public const string ClearReaction = ":no_entry_sign:";
         public const string RefreshReaction = ":arrows_counterclockwise:";
 
-        private const string SignupChannelName = "events";
+        public const string SignupChannelName = "events";
 
         private static readonly string[] EventOperations =
         {

--- a/DiscordBot/Program.cs
+++ b/DiscordBot/Program.cs
@@ -48,16 +48,17 @@ namespace DiscordBot
             var reactionBuffer = new ReactionBuffer(eventsSheetsService);
 
             discord.UseInteractivity(new InteractivityConfiguration());
-            discord.MessageReactionAdded += async (client, eventArguments) =>
+            discord.MessageReactionAdded += (client, eventArguments) =>
             {
-                await OnMessageReactionAdded(client, eventArguments, eventsSheetsService, reactionBuffer);
+                OnMessageReactionAdded(client, eventArguments, eventsSheetsService, reactionBuffer);
+                return Task.CompletedTask;
             };
 
             await discord.ConnectAsync();
             await Task.Delay(-1);
         }
 
-        private static Task OnMessageReactionAdded(
+        private static void OnMessageReactionAdded(
             DiscordClient client,
             MessageReactionAddEventArgs eventArguments,
             IEventsSheetsService eventsSheetsService,
@@ -66,20 +67,18 @@ namespace DiscordBot
             // Skip if event was triggered by the bot
             if (eventArguments.User == client.CurrentUser)
             {
-                return Task.CompletedTask;
+                return;
             }
 
             // Skip if reaction is not in the signup channel
             if (eventArguments.Channel.Name != EventCommands.SignupChannelName)
             {
-                return Task.CompletedTask;
+                return;
             }
 
             _ = Task.Run(async () =>
                 await ProcessReaction(eventArguments, eventsSheetsService, reactionBuffer)
             );
-
-            return Task.CompletedTask;
         }
 
         private static async Task ProcessReaction(

--- a/DiscordBot/Program.cs
+++ b/DiscordBot/Program.cs
@@ -76,9 +76,8 @@ namespace DiscordBot
             }
 
             _ = Task.Run(async () =>
-            {
-                await ProcessReaction(eventArguments, eventsSheetsService, reactionBuffer);
-            });
+                await ProcessReaction(eventArguments, eventsSheetsService, reactionBuffer)
+            );
 
             return Task.CompletedTask;
         }
@@ -104,7 +103,6 @@ namespace DiscordBot
             MessageReactionAddEventArgs eventArguments,
             IEventsSheetsService eventsSheetsService)
         {
-
             var discordEvent = await GetEventFromMessageIdOrDefaultAsync(eventArguments.Message.Id, eventsSheetsService);
             if (discordEvent != null)
             {


### PR DESCRIPTION
The front end now uses the batched reaction handling.

The message once again refreshes automatically on signups.

Managed to avoid adding the client to the buffer with the trade-off of removing DM confirmations, which would have been difficult to implement in batches anyways as invalid responses are silently ignored.